### PR TITLE
Moved the About Us screen over to Jetpack Compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ local.properties
 .gradle
 /.idea/workspace.xml
 /.idea/libraries
+.idea/.name
 .idea/caches/
 .idea/codeStyles/codeStyleConfig.xml
 .DS_Store

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,19 +2,32 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
+apply plugin: 'dagger.hilt.android.plugin'
 
 android {
     compileSdkVersion 31
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_11
+        useIR = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion compose_version
+    }
+
     buildFeatures {
         dataBinding = true
+        compose = true
     }
+
     defaultConfig {
         applicationId "com.gocoronago.tracker"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 31
         versionCode 4
         versionName "4.0"
@@ -51,6 +64,21 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+
+    // Hilt
+    implementation "com.google.dagger:hilt-android:2.38.1"
+    implementation "androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha03"
+    implementation 'androidx.hilt:hilt-navigation-compose:1.0.0-alpha03'
+    kapt "com.google.dagger:hilt-android-compiler:2.36"
+    kapt "androidx.hilt:hilt-compiler:1.0.0"
+
+    // Compose Deps
+    implementation "androidx.compose.ui:ui:$compose_version"
+    implementation "androidx.compose.material:material:$compose_version"
+    implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
+    implementation 'androidx.activity:activity-compose:1.3.1'
+
 
     implementation 'com.github.angads25:toggle:1.1.0'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:icon="@mipmap/ic_launcher_icon"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_icon_round"
+        android:name=".GoCoronaGoApplication"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         android:fullBackupContent="@xml/backup_descriptor">

--- a/app/src/main/java/com/example/gocoronago/GoCoronaGoApplication.kt
+++ b/app/src/main/java/com/example/gocoronago/GoCoronaGoApplication.kt
@@ -1,0 +1,7 @@
+package com.example.gocoronago
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class GoCoronaGoApplication : Application()

--- a/app/src/main/java/com/example/gocoronago/MainActivity.kt
+++ b/app/src/main/java/com/example/gocoronago/MainActivity.kt
@@ -12,9 +12,11 @@ import androidx.fragment.app.Fragment
 import com.example.gocoronago.about.AboutFragment
 import com.example.gocoronago.ui.main.MainFragment
 import com.github.angads25.toggle.widget.LabeledSwitch
+import dagger.hilt.android.AndroidEntryPoint
 
 private var darkMode = true
 
+@AndroidEntryPoint
 open class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/example/gocoronago/about/AboutFragment.kt
+++ b/app/src/main/java/com/example/gocoronago/about/AboutFragment.kt
@@ -1,45 +1,25 @@
 package com.example.gocoronago.about
 
-import android.content.pm.PackageManager
 import android.os.Bundle
-import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.View
 import android.view.ViewGroup
-import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
-import android.widget.LinearLayout
-import android.widget.TextView
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
 import com.example.gocoronago.MainActivity
 import com.example.gocoronago.R
-import kotlinx.android.synthetic.main.about_fragment.*
+import com.example.gocoronago.about.ui.AboutUsScreen
+import dagger.hilt.android.AndroidEntryPoint
 
-/**
- * Created by haqiqiw on 07/10/20.
- */
+@AndroidEntryPoint
 class AboutFragment : Fragment() {
 
-    private val contributors = listOf(
-        Contributor("Ritwik Shanker", "🇮🇳", true),
-        Contributor("Sunny", "🇮🇳"),
-        Contributor("M. Asrof Bayhaqqi", "🇮🇩"),
-        Contributor("Jacob", "\uD83C\uDDF7\uD83C\uDDFA"),
-        Contributor("Matthew Scibilia", "\uD83C\uDDE6\uD83C\uDDFA"),
-        Contributor("MR Abdhi P", "🇮🇩")
-    )
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View = inflater.inflate(R.layout.about_fragment, container, false)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupNavBar()
-        renderVersion()
-        renderContributors()
     }
 
     private fun setupNavBar() {
@@ -56,41 +36,20 @@ class AboutFragment : Fragment() {
         super.onPrepareOptionsMenu(menu)
     }
 
-    private fun renderVersion() {
-        try {
-            val pInfo = requireContext().packageManager.getPackageInfo(
-                requireContext().packageName, 0
-            )
-            val version = pInfo?.versionName
-            textVersion.text = version
-        } catch (e: PackageManager.NameNotFoundException) {
-            e.printStackTrace()
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View = ComposeView(requireContext()).apply {
+        setViewCompositionStrategy(
+            ViewCompositionStrategy.DisposeOnLifecycleDestroyed(viewLifecycleOwner)
+        )
+
+        setContent {
+            AboutUsScreen()
         }
     }
 
-    private fun renderContributors() {
-        containerContributors?.apply {
-            removeAllViews()
-            contributors.mapIndexed { index, item ->
-                addView(
-                    createContributorTextView(index, item),
-                    LinearLayout.LayoutParams(WRAP_CONTENT, WRAP_CONTENT)
-                )
-            }
-        }
-    }
-
-    private fun createContributorTextView(index: Int, contributor: Contributor): TextView {
-        val contributorText = "${contributor.flag} ${contributor.name}" +
-                if (contributor.owner) " (Owner)" else ""
-        return TextView(requireContext()).apply {
-            text = contributorText
-            setTextSize(TypedValue.COMPLEX_UNIT_SP, 14f)
-            setPadding(0, if (index == 0) 0 else 4, 0, 0)
-        }
-    }
-
-    data class Contributor(val name: String, val flag: String, val owner: Boolean = false)
 
     companion object {
         fun newInstance() = AboutFragment()

--- a/app/src/main/java/com/example/gocoronago/about/model/Contributor.kt
+++ b/app/src/main/java/com/example/gocoronago/about/model/Contributor.kt
@@ -1,0 +1,3 @@
+package com.example.gocoronago.about.model
+
+data class Contributor(val name: String, val flag: String, val owner: Boolean = false)

--- a/app/src/main/java/com/example/gocoronago/about/repository/AboutUsRepository.kt
+++ b/app/src/main/java/com/example/gocoronago/about/repository/AboutUsRepository.kt
@@ -1,0 +1,30 @@
+package com.example.gocoronago.about.repository
+
+import com.example.gocoronago.BuildConfig
+import com.example.gocoronago.about.model.Contributor
+import javax.inject.Inject
+
+interface IAboutUsRepository {
+    fun getVersionName(): String
+    fun getContributorList(): List<Contributor>
+}
+
+
+class AboutUsRepository @Inject constructor() : IAboutUsRepository {
+
+    override fun getVersionName(): String {
+        return BuildConfig.VERSION_NAME
+    }
+
+    override fun getContributorList(): List<Contributor> {
+        return listOf(
+            Contributor("Ritwik Shanker", "🇮🇳", true),
+            Contributor("Sunny", "🇮🇳"),
+            Contributor("M. Asrof Bayhaqqi", "🇮🇩"),
+            Contributor("Jacob", "\uD83C\uDDF7\uD83C\uDDFA"),
+            Contributor("Matthew Scibilia", "\uD83C\uDDE6\uD83C\uDDFA"),
+            Contributor("MR Abdhi P", "🇮🇩"),
+            Contributor("Ben Kadel", "\uD83C\uDDEC\uD83C\uDDE7")
+        )
+    }
+}

--- a/app/src/main/java/com/example/gocoronago/about/ui/AboutUsScreen.kt
+++ b/app/src/main/java/com/example/gocoronago/about/ui/AboutUsScreen.kt
@@ -1,0 +1,100 @@
+package com.example.gocoronago.about.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Divider
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.gocoronago.R
+import com.example.gocoronago.about.model.Contributor
+import com.example.gocoronago.about.viewmodel.AboutUsViewModel
+
+
+@Composable
+fun AboutUsScreen(
+    viewmodel: AboutUsViewModel = hiltViewModel()
+) {
+    val versionName by viewmodel.versionName
+    val contributors by viewmodel.contributors
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        TitleBlock()
+        Divider(color = Color(0x37000000), thickness = 1.dp)
+        VersionBlock(versionName)
+        Divider(color = Color(0x37000000), thickness = 1.dp)
+        ContributorsBlock(contributors)
+        Divider(color = Color(0x37000000), thickness = 1.dp)
+    }
+}
+
+@Composable
+fun TitleBlock() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp), horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Image(
+            modifier = Modifier.size(100.dp),
+            painter = painterResource(id = R.drawable.ic_about),
+            contentDescription = null
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = stringResource(id = R.string.gocoronago),
+            style = TextStyle(fontSize = 28.sp, color = Color(0xFF757575))
+        )
+        Text(
+            text = stringResource(id = R.string.app_name),
+            style = TextStyle(fontSize = 16.sp, color = Color(0xFF757575))
+        )
+    }
+}
+
+@Composable
+fun VersionBlock(
+    versionName: String
+) {
+    Column(modifier = Modifier.padding(16.dp)) {
+        Text(
+            text = stringResource(id = R.string.version),
+            style = TextStyle(fontSize = 18.sp, color = Color(0xFF757575))
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(text = versionName, style = TextStyle(fontSize = 14.sp, color = Color(0xFF757575)))
+    }
+}
+
+@Composable
+fun ContributorsBlock(
+    contributors: List<Contributor>
+) {
+    Column(modifier = Modifier.padding(16.dp)) {
+        Text(
+            text = stringResource(id = R.string.contributors),
+            style = TextStyle(fontSize = 18.sp, color = Color(0xFF757575))
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        contributors.forEach {
+            var contributorString = "${it.flag} ${it.name}"
+            if (it.owner) {
+                contributorString += " (Owner)"
+            }
+            Text(
+                text = contributorString,
+                style = TextStyle(fontSize = 14.sp, color = Color(0xFF757575))
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+        }
+    }
+}

--- a/app/src/main/java/com/example/gocoronago/about/usecase/GetContributorListUseCase.kt
+++ b/app/src/main/java/com/example/gocoronago/about/usecase/GetContributorListUseCase.kt
@@ -1,0 +1,17 @@
+package com.example.gocoronago.about.usecase
+
+import com.example.gocoronago.about.model.Contributor
+import com.example.gocoronago.about.repository.IAboutUsRepository
+import javax.inject.Inject
+
+interface IGetContributorListUseCase {
+    operator fun invoke(): List<Contributor>
+}
+
+class GetContributorListUseCase @Inject constructor(
+    private val repo: IAboutUsRepository
+) : IGetContributorListUseCase {
+    override fun invoke(): List<Contributor> {
+        return repo.getContributorList()
+    }
+}

--- a/app/src/main/java/com/example/gocoronago/about/usecase/GetVersionNameUseCase.kt
+++ b/app/src/main/java/com/example/gocoronago/about/usecase/GetVersionNameUseCase.kt
@@ -1,0 +1,16 @@
+package com.example.gocoronago.about.usecase
+
+import com.example.gocoronago.about.repository.IAboutUsRepository
+import javax.inject.Inject
+
+interface IGetVersionNameUseCase {
+    operator fun invoke(): String
+}
+
+class GetVersionNameUseCase @Inject constructor(
+    val repo: IAboutUsRepository
+) : IGetVersionNameUseCase {
+    override fun invoke(): String {
+        return repo.getVersionName()
+    }
+}

--- a/app/src/main/java/com/example/gocoronago/about/viewmodel/AboutUsViewModel.kt
+++ b/app/src/main/java/com/example/gocoronago/about/viewmodel/AboutUsViewModel.kt
@@ -1,0 +1,25 @@
+package com.example.gocoronago.about.viewmodel
+
+import android.util.Log
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import com.example.gocoronago.about.model.Contributor
+import com.example.gocoronago.about.usecase.IGetContributorListUseCase
+import com.example.gocoronago.about.usecase.IGetVersionNameUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class AboutUsViewModel @Inject constructor(
+    getVersionNameUseCase: IGetVersionNameUseCase,
+    getContributorListUseCase: IGetContributorListUseCase
+) : ViewModel() {
+
+    private val _versionName: MutableState<String> = mutableStateOf(getVersionNameUseCase())
+    val versionName: State<String> = _versionName
+
+    private val _contributors: MutableState<List<Contributor>> = mutableStateOf(getContributorListUseCase())
+    val contributors: State<List<Contributor>> = _contributors
+}

--- a/app/src/main/java/com/example/gocoronago/di/AppModule.kt
+++ b/app/src/main/java/com/example/gocoronago/di/AppModule.kt
@@ -1,0 +1,38 @@
+package com.example.gocoronago.di
+
+import com.example.gocoronago.about.repository.AboutUsRepository
+import com.example.gocoronago.about.repository.IAboutUsRepository
+import com.example.gocoronago.about.usecase.GetContributorListUseCase
+import com.example.gocoronago.about.usecase.GetVersionNameUseCase
+import com.example.gocoronago.about.usecase.IGetContributorListUseCase
+import com.example.gocoronago.about.usecase.IGetVersionNameUseCase
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+class AppModule {
+
+
+    @Module
+    @InstallIn(SingletonComponent::class)
+    interface InnerAppModule {
+
+        @Binds
+        @Singleton
+        fun provideGetContributorListUseCase(usecase: GetContributorListUseCase) :IGetContributorListUseCase
+
+        @Binds
+        @Singleton
+        fun provideGetVersionNameUseCase(usecase: GetVersionNameUseCase) :IGetVersionNameUseCase
+
+        @Binds
+        @Singleton
+        fun provideAboutUsRepository(repo: AboutUsRepository) :IAboutUsRepository
+
+    }
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -2,14 +2,15 @@
 buildscript {
     ext.kotlin_version = "1.5.30"
     ext.android_plugin_version = '7.0.2'
+    ext.compose_version = '1.0.3'
     repositories {
         google()
         jcenter()
     }
     dependencies {
         classpath "com.android.tools.build:gradle:$android_plugin_version"
-        classpath 'com.android.tools.build:gradle:7.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "com.google.dagger:hilt-android-gradle-plugin:2.38.1"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Addressed this issue: #57 

Here is what I did:
* Added Jetpack compose settings and dependencies to codebase
* Wrote the Composable functions copying the layout of the old xml about us fragment layout
* Added **Hilt** dependency too for Dependency Injection
* Set up the package structure for clean MVVM approach for the **About Us** screen package
* Created the `AboutUsViewModel` , `AboutUsUseCases` & `AboutUsRepository` to make the package clean MVVM and connected the pieces together
* Finally the data gathered in the ViewModel was presented to the Compose UI as Compose States and compose rendered the data
* Also added my own name to the contributor list